### PR TITLE
Update entry: Alfresco Export Scripts (alfresco-export-scripts-75)

### DIFF
--- a/content/entries/alfresco-export-scripts-75.md
+++ b/content/entries/alfresco-export-scripts-75.md
@@ -1,14 +1,14 @@
 ---
-title: "Alfresco Export-Scripts"
+title: "Alfresco Export Scripts"
 description: "A colletion of simple shell scripts for extracting information from Alfresco Repository."
-screenshots: ["_No response_"]
+screenshots: ["https://opengraph.githubassets.com/1/zylklab/alfresco-export-scripts"]
 compatibility: ["ACS 5.x","ACS 6.x","ACS 7.x","ACS 23.1","ACS 23.2","ACS 23.3","ACS 23.4","ACS 23.x","ACS 25.1","ACS 25.2","ACS 25.x"]
 license: "GPL-3.0-or-later"
 keywords: ["ACS","export","import","bulk","shell"]
 download_url: "https://github.com/zylklab/alfresco-export-scripts"
-vendor: "Cesar Capillas"
+vendor: "ZYLK S.L."
 about: "Alfresco shell scripts for extracting user, groups, sites, data, metadata and permission information from Alfresco repository."
-about_url: "_No response_"
+about_url: "https://github.com/zylklab/alfresco-export-scripts"
 draft: false
 ---
 


### PR DESCRIPTION
## Summary

- Fix title: `Alfresco Export-Scripts` → `Alfresco Export Scripts` (removes hyphen)
- Update vendor: `Cesar Capillas` → `ZYLK S.L.`
- Add screenshot: `https://opengraph.githubassets.com/1/zylklab/alfresco-export-scripts`
- Add `about_url`: `https://github.com/zylklab/alfresco-export-scripts`

Closes #77