### PR TITLE
Update entry: alfresco-share-online-edition-addon (alfresco-share-online-edition-addon-79)

### DIFF
--- a/content/entries/alfresco-share-online-edition-addon-79.md
+++ b/content/entries/alfresco-share-online-edition-addon-79.md
@@ -1,5 +1,5 @@
 ---
-title: "alfresco-share-online-edition-addon"
+title: "Edit online with Libreoffice in Alfresco Share"
 description: "Edit with Libreoffice in Alfresco Share addon provides a simple webdav link for online edition of common MS-Office and Libreoffice mimetypes in Alfresco Share."
 screenshots: ["https://opengraph.githubassets.com/1/zylklab/alfresco-share-online-edition-addon"]
 compatibility: ["ACS 4.x","ACS 5.x","ACS 6.x","ACS 7.x","ACS 23.x","ACS 25.x"]


### PR DESCRIPTION
## Summary

- Updates title of `alfresco-share-online-edition-addon-79` from `alfresco-share-online-edition-addon` to `Edit online with Libreoffice in Alfresco Share` as requested in #81
- Verified no duplicate entry exists: `libreoffice-online-edit-module-3227.md` is a different addon by Redpill-Linpro, not related to the Zylk entry

Closes #81